### PR TITLE
ci: report lint, type-check and build status on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+# Read-only. This workflow validates a proposed change; it never publishes one.
+permissions:
+  contents: read
+
+# A new push to the same pull request supersedes the run already in flight.
+concurrency:
+  group: "ci-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Lint, type-check and build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Each check is its own step so a failure names which one broke,
+      # and the remaining checks still report rather than being masked.
+      - name: Lint
+        run: npm run lint
+
+      - name: Type-check
+        if: ${{ !cancelled() }}
+        run: npm run typecheck
+
+      - name: Build
+        if: ${{ !cancelled() }}
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "typecheck": "tsc -b",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "preview": "vite preview",


### PR DESCRIPTION
Closes #7

## What and why

Pull requests received no automated signal — the only workflow deployed on push to `main`,
and `npm run lint` was never invoked by CI at all. Both pull requests merged so far
reported zero checks. This adds a read-only `CI` workflow on the `pull_request` trigger
that runs lint, type-check and build as three separate steps, so a red check names which
one broke.

## Acceptance criteria

- [x] A status check runs and reports on every pull request against `main` — `.github/workflows/ci.yml:4-6`
- [x] A lint error fails the check and names the offending file — verified locally: a probe file with an unused variable gave `npm run lint` exit 1 and printed the file path
- [x] A TypeScript type error fails the check — verified locally: `const wrong: number = "not a number"` gave `npm run typecheck` exit 2
- [x] A build that does not complete fails the check — verified locally: an unresolvable import reachable from `src/main.tsx` gave `npm run build` exit 1 with `Could not resolve "./does-not-exist-abc.png"`
- [x] All checks green when the tree is clean, and merge is not blocked by this change — no branch-protection rule is configured here (see Out of scope)

## Existing code reused

- Matched `deploy.yml` step for step where the two overlap: `actions/checkout@v4`,
  `actions/setup-node@v4` with `node-version: '20'` and `cache: 'npm'`, and `npm ci`.
- `npm run lint` and `npm run build` are the existing scripts, invoked unchanged.
- The one addition to `package.json` is `"typecheck": "tsc -b"`, which names the type-check
  phase `build` already ran. No new dependency was added — nothing needed one.

## Design notes

No application architecture is touched; this is workflow configuration only.

**Separate workflow rather than extending `deploy.yml`.** The alternative was adding a
`pull_request` trigger to the existing workflow and guarding the deploy job with an `if:`.
Rejected on permissions: `deploy.yml` declares `pages: write` and `id-token: write` at the
workflow level, so triggering it from pull requests would hand those to unmerged code. The
new workflow declares `permissions: contents: read` and nothing else.

**`pull_request`, not `pull_request_target`.** `pull_request_target` runs the base branch's
workflow with repository credentials against contributor code; it is not needed here and is
the more dangerous of the two.

Three separate steps rather than one chained command, so the failing check is identifiable
from the step name. `Type-check` and `Build` carry `if: ${{ !cancelled() }}` so a lint
failure still lets the later checks report instead of masking them. `concurrency` with
`cancel-in-progress` supersedes an in-flight run when the branch is pushed again.

## Verification

Run on this branch, against the exact commands CI invokes:

- `npm run lint` — clean, exit 0
- `npm run typecheck` — clean, exit 0
- `npm run build` — clean, exit 0, `tsc -b` writes nothing into the working tree

Each check was then confirmed to actually fail on bad input, and the tree restored — see
the acceptance criteria above for the four probes and their exit codes.

## Out of scope

- `deploy.yml` still does not run lint on push to `main`. Left alone deliberately; changing
  the deploy path is not what this story asked for, and `npm run build` there already
  covers type-check and build.
- No test step. The repository has no test suite yet; that gap is tracked under #6.
- No branch-protection rule requiring these checks. That is a repository setting rather than
  a file in this diff, and needs an admin to apply it — worth doing once this has run green
  a few times.

## Review focus

The permissions reasoning is the part most worth a second opinion: `ci.yml:10-11` grants
`contents: read` only, on the assumption nothing in lint, type-check or build needs more.

*Implemented automatically from #7. Not reviewed, not merged.*
