### PR TITLE
feat(ui): render the CV as always-present, accessible page text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Game } from './game/game';
 import { DialogAction, DialogContent, SceneName } from './game/events';
+import { CvContent } from './ui/CvContent';
 import { DialogPanel } from './ui/DialogPanel';
 import { GameCanvas } from './ui/GameCanvas';
 import { HUD } from './ui/HUD';
@@ -57,6 +58,7 @@ function App() {
 
   return (
     <div className="game-root">
+      <CvContent />
       <GameCanvas onGame={setGame} />
       {started && <HUD prompt={dialog ? null : prompt} scene={scene} isTouch={isTouch} />}
       {started && isTouch && !dialog && game && <TouchControls virtual={game.virtualInput} />}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,10 @@
+// Vitest has no built-in equivalent of Jest's auto-cleanup for React
+// Testing Library, so each RTL render would otherwise stay mounted into the
+// next test in the same file. This is Testing Library's own documented fix:
+// https://testing-library.com/docs/react-testing-library/setup#cleanup
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});

--- a/src/ui/CvContent.test.tsx
+++ b/src/ui/CvContent.test.tsx
@@ -1,0 +1,74 @@
+// Proves CvContent satisfies #8's four acceptance criteria as far as a DOM
+// test can: every entry from the three named data modules is present as
+// text (AC1/AC3), and the section/entry structure exposes real heading
+// levels with names that reflect their place in the outline (AC4).
+// AC2 (browser find-in-page) rests on the .sr-only technique itself - a
+// clip-rect hidden box, not display:none/visibility:hidden/aria-hidden -
+// which is the standard, widely-documented pattern relied on precisely
+// because browsers still search and expose that text; there is no way to
+// drive a browser's native find-in-page from this test runner to assert it
+// directly, so this file instead asserts the technique used is that one.
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { education } from '../data/education';
+import { hobbies } from '../data/hobbies';
+import { gardenBeds, pottedPlants, rackTools } from '../data/skills';
+import { workExperience } from '../data/work-experience';
+import { CvContent } from './CvContent';
+
+describe('CvContent', () => {
+  it('is present via the sr-only technique, not display:none or aria-hidden', () => {
+    const { container } = render(<CvContent />);
+    const root = container.firstElementChild!;
+    expect(root.className).toContain('sr-only');
+    expect(root.getAttribute('aria-hidden')).toBeNull();
+    expect(getComputedStyle(root).display).not.toBe('none');
+  });
+
+  it('exposes exactly one h1, naming the person', () => {
+    render(<CvContent />);
+    const h1s = screen.getAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0].textContent).toContain('Magnus Arnild');
+  });
+
+  it('exposes one h2 per major section, in outline order', () => {
+    render(<CvContent />);
+    const h2s = screen.getAllByRole('heading', { level: 2 });
+    expect(h2s.map((h) => h.textContent)).toEqual(['Work Experience', 'Education', 'Skills', 'Hobbies']);
+  });
+
+  it('gives every work-experience, education and hobby entry its own h3', () => {
+    render(<CvContent />);
+    const h3s = screen.getAllByRole('heading', { level: 3 }).map((h) => h.textContent);
+    for (const item of workExperience) expect(h3s).toContain(`${item.title} — ${item.organization}`);
+    for (const item of education) expect(h3s).toContain(`${item.title} — ${item.organization}`);
+    for (const hobby of hobbies) expect(h3s).toContain(hobby.name);
+  });
+
+  it('includes every work-experience entry as text', () => {
+    const { container } = render(<CvContent />);
+    for (const item of workExperience) {
+      expect(container.textContent).toContain(item.organization);
+      expect(container.textContent).toContain(item.period);
+    }
+  });
+
+  it('includes every education entry as text', () => {
+    const { container } = render(<CvContent />);
+    for (const item of education) {
+      expect(container.textContent).toContain(item.organization);
+      expect(container.textContent).toContain(item.period);
+    }
+  });
+
+  it('includes every skills entry as text: garden beds, potted plants and rack tools', () => {
+    const { container } = render(<CvContent />);
+    for (const bed of gardenBeds) {
+      expect(container.textContent).toContain(bed.name);
+      for (const skill of bed.skills) expect(container.textContent).toContain(skill);
+    }
+    for (const plant of pottedPlants) expect(container.textContent).toContain(plant.name);
+    for (const tool of rackTools) expect(container.textContent).toContain(tool.name);
+  });
+});

--- a/src/ui/CvContent.tsx
+++ b/src/ui/CvContent.tsx
@@ -1,0 +1,87 @@
+import { education } from '../data/education';
+import { hobbies } from '../data/hobbies';
+import { profileData, summary } from '../data/profile';
+import { gardenBeds, pottedPlants, rackTools } from '../data/skills';
+import { workExperience } from '../data/work-experience';
+import { TimelineItem } from '../data/types';
+
+// Always-mounted, visually-hidden text rendering of the CV. The game canvas
+// is aria-hidden and its dialogs only exist once a visitor has walked to and
+// interacted with something, so without this the CV has no representation
+// outside the canvas at all - unreachable by a screen reader, invisible to
+// find-in-page, and absent from the DOM for anything that doesn't play.
+//
+// This deliberately reads straight from src/data/*.ts rather than through
+// game/content/dialogs.ts's mapper functions (careerDialog, educationDialog,
+// etc.): those build a flat { meta, lines, tags } shape for a single game
+// dialog at a time, not a nested heading outline across many entries, and
+// their phrasing (e.g. the "(part-time)" suffix, combined meta strings) is
+// tuned for a compact dialog panel rather than a linear document. Reading
+// the data directly is simpler than routing through a shape built for a
+// different reader.
+export function CvContent() {
+  return (
+    <div className="sr-only">
+      <h1>
+        {profileData.name} — {profileData.title}
+      </h1>
+      <p>{profileData.bio}</p>
+      <p>{summary}</p>
+
+      <h2>Work Experience</h2>
+      {workExperience.map((item) => (
+        <TimelineEntry key={`${item.organization}-${item.period}`} item={item} />
+      ))}
+
+      <h2>Education</h2>
+      {education.map((item) => (
+        <TimelineEntry key={`${item.organization}-${item.period}`} item={item} />
+      ))}
+
+      <h2>Skills</h2>
+      {gardenBeds.map((bed) => (
+        <section key={bed.name}>
+          <h3>{bed.name}</h3>
+          <p>{bed.skills.join(', ')}</p>
+        </section>
+      ))}
+      {pottedPlants.length > 0 && (
+        <section>
+          {/* One shared heading for every plant, matching how the tool rack
+              below (and the game's own toolRackDialog) already groups many
+              small items under a single heading rather than one each. */}
+          <h3>Also developing</h3>
+          <p>{pottedPlants.map((plant) => plant.name).join(', ')}</p>
+        </section>
+      )}
+      {rackTools.length > 0 && (
+        <section>
+          <h3>Tools</h3>
+          <p>{rackTools.map((tool) => tool.name).join(', ')}</p>
+        </section>
+      )}
+
+      <h2>Hobbies</h2>
+      {hobbies.map((hobby) => (
+        <section key={hobby.name}>
+          <h3>{hobby.name}</h3>
+          <p>{hobby.description}</p>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function TimelineEntry({ item }: { item: TimelineItem }) {
+  return (
+    <section>
+      <h3>
+        {item.title} — {item.organization}
+      </h3>
+      <p>
+        {item.location} · {item.period}
+      </p>
+      {item.description?.map((line) => <p key={line}>{line}</p>)}
+    </section>
+  );
+}

--- a/src/ui/StartScreen.tsx
+++ b/src/ui/StartScreen.tsx
@@ -13,8 +13,10 @@ export function StartScreen({ onStart, isTouch }: StartScreenProps) {
     <div className="start-screen">
       <div className="pixel-panel start-panel">
         <img className="start-photo" src={profileData.imageUrl} alt="Photo of Magnus Arnild" />
-        <h1>Magnus Arnild</h1>
-        <h2>Software Engineer · Interactive CV</h2>
+        {/* h2/h3, not h1/h2: CvContent (always mounted, see App.tsx) owns the
+            page's one h1, and this panel unmounts once the game starts. */}
+        <h2>Magnus Arnild</h2>
+        <h3>Software Engineer · Interactive CV</h3>
         <p>
           Welcome to my little pixel-world CV! Walk around and find out about me: the forest holds
           my career, the garden grows my skills, the mountains represent my education — and my

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -257,14 +257,14 @@
   margin-bottom: 16px;
 }
 
-.start-panel h1 {
+.start-panel h2 {
   font-size: 18px;
   margin: 0 0 10px;
   color: var(--accent);
   line-height: 1.5;
 }
 
-.start-panel h2 {
+.start-panel h3 {
   font-size: 10px;
   margin: 0 0 20px;
   color: #7a5230;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
   base: '/curriculum-vitae/', // Base path for GitHub Pages
   test: {
     environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
   },
 })


### PR DESCRIPTION
Closes #8

## What and why

`GameCanvas.tsx` sets `aria-hidden="true"` on the only element that carried CV content, and
career/education detail only ever existed once a visitor walked to and interacted with a
specific object. Nothing survived a screen reader, find-in-page, or a client that renders
the page without running the canvas animation loop. This adds `CvContent`, an
always-mounted, visually-hidden semantic rendering of the whole CV, and fixes a heading
conflict its addition exposed in `StartScreen`.

## Acceptance criteria

- [x] Every entry in `work-experience.ts`, `education.ts` and `skills.ts` is announced as
      page content with no interaction needed — `CvContent.tsx` renders all of them
      unconditionally; verified in-browser (Verification) and by `CvContent.test.tsx`
- [x] Browser find-in-page finds any employer/institution name — rests on the `.sr-only`
      technique itself (a real, clipped-but-rendered box, not `display:none` /
      `aria-hidden`), the standard pattern relied on precisely because it stays searchable;
      see Design notes for why this can't be asserted directly in a test
- [x] The CV text is present in the document for a client that doesn't run the animation
      loop — confirmed live: `document.body.textContent` contains `"Kompasbank"` and
      `"HHX"` immediately after page load, before and after the game starts
- [x] Every CV section exposes a heading level and accessible name reflecting its place in
      the outline — one `<h1>`, four `<h2>` sections in order, one `<h3>` per entry;
      confirmed live (28 headings, correct nesting) and by `CvContent.test.tsx`

## Existing code reused

- The `.sr-only` CSS class already existed (`ui.css`, used once by `StartScreen`) — reused
  verbatim, no second hidden-content technique introduced.
- `CvContent` reads directly from `src/data/*.ts` rather than through
  `game/content/dialogs.ts`'s mapper functions (`careerDialog`, `educationDialog`, etc.).
  Those build a flat `{ meta, lines, tags }` shape for a single game dialog at a time, with
  phrasing tuned for a compact panel (a `(part-time)` suffix, combined meta strings) — not
  a nested heading outline across many entries at once. There was nothing to usefully share
  between the two without distorting one to fit the other.
- Grouped `pottedPlants` and `rackTools` under one shared `<h3>` each, matching how the
  game's own `toolRackDialog()` already groups every tool into a single dialog rather than
  one per tool.

## Design notes

No architecture change — one new presentational React component plus the two files needed
to keep the heading outline correct once it exists.

**A real semantic heading outline, not ARIA landmarks or a live region.** The four
acceptance criteria are about accessibility-tree presence, DOM text, and heading structure
— none require visual display. A plain, properly-nested `<h1>`/`<h2>`/`<h3>` document
inside `.sr-only` satisfies all four without pre-empting the separate, larger "single
scrolling page" redesign the epic (#4) and `.claude/backlog-conventions.md` describe — that
is a future initiative involving what's actually *shown*; this story only needed what's
*reachable*.

**The `StartScreen` heading conflict was found, not created by choice.** `CvContent` needed
to own the page's one `<h1>` because it's the only thing always mounted — `StartScreen`
unmounts entirely on Explore, so if it kept its own `<h1>`, the page would have two while
the start screen shows and zero afterwards. Demoting `StartScreen`'s `<h1>`/`<h2>` to
`<h2>`/`<h3>` and updating the two CSS rules that targeted those tag names directly
(`ui.css`) was required for this story's own correctness, not a drive-by cleanup — verified
visually unchanged before and after (see Verification).

**AC2 (find-in-page) can't be driven from a test runner.** `CvContent.test.tsx` instead
asserts the mechanism that makes it true: the wrapper has the `sr-only` class, no
`aria-hidden`, and a non-`none` `display` — the same properties that make this exact
technique searchable in every major browser. Confirmed live in the browser as well
(`display: block`, 1×1px box, `aria-hidden` absent).

**Test isolation gap found and fixed, not routed around.** The first version of
`CvContent.test.tsx`'s heading-count assertion failed with headings tripled — Vitest has no
built-in equivalent of Jest's RTL auto-cleanup, so each `render()` in the file stayed
mounted into the next test. Added `src/test-setup.ts` wired through `vite.config.ts`'s
`setupFiles`, registering `afterEach(cleanup)` once for every test file — Testing Library's
own documented fix (linked in the commit), not an invented convention. This will apply to
every future RTL test in the repo, not just this one.

## Verification

- `npm run lint` / `npm run typecheck` / `npm run test` (32 passed) / `npm run build` — all
  clean on the final commit
- Broke a `CvContent.test.tsx` assertion deliberately (impossible string), confirmed
  `npm test` exits 1 with 2 failing tests, restored it, confirmed exit 0 with all 32 passing
- Ran the app in a real browser, before and after clicking Explore:
  - Screenshots: `StartScreen` visually unchanged (heading sizes, layout)
  - `document.querySelectorAll('h1').length === 1` in both states
  - `document.querySelectorAll('h2,h3').length` matches the expected section/entry count
    (28 headings total), in the right order
  - The `.sr-only` element is a real DOM node: `display: block`, a 1×1px box, no
    `aria-hidden` attribute
  - `document.body.textContent` contains `"Kompasbank"` and `"HHX"` in both states

## Out of scope

- The visible, "single scrolling page" redesign the epic describes — this story delivers
  the accessible/reachable half, not the visual one; that's larger, separate work already
  tracked at epic level.
- `DialogPanel`'s own internal heading levels (`<h2>`/`<h3>` inside the modal) are
  unchanged. A `role="dialog"` subtree isn't part of the page's linear reading order while
  open, so it doesn't need to continue the outline `CvContent` establishes.
- No landmark roles (`<main>`, etc.) added — not required by any of the four criteria, and
  risked overlapping with layout decisions the larger redesign hasn't made yet.

## Review focus

The `StartScreen` heading/CSS change is the part most worth a second look — it's a
necessary side effect of this story rather than its main point, easy to skim past, and the
one place a silent visual regression could have slipped through if the before/after
screenshots hadn't been checked.

*Implemented automatically from #8. Not reviewed, not merged.*
