### PR TITLE
feat(ui): let a visitor read the CV on screen without playing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ function App() {
   const [dialog, setDialog] = useState<DialogContent | null>(null);
   const [prompt, setPrompt] = useState<string | null>(null);
   const [scene, setScene] = useState<SceneName>('overworld');
+  const [cvVisible, setCvVisible] = useState(false);
 
   const isTouch = useMemo(
     () =>
@@ -58,14 +59,16 @@ function App() {
 
   return (
     <div className="game-root">
-      <CvContent />
+      <CvContent visible={cvVisible} onClose={() => setCvVisible(false)} />
       <GameCanvas onGame={setGame} />
       {started && <HUD prompt={dialog ? null : prompt} scene={scene} isTouch={isTouch} />}
       {started && isTouch && !dialog && game && <TouchControls virtual={game.virtualInput} />}
       {dialog && (
         <DialogPanel content={dialog} onClose={closeDialog} onAction={handleDialogAction} isTouch={isTouch} />
       )}
-      {!started && <StartScreen onStart={() => setStarted(true)} isTouch={isTouch} />}
+      {!started && (
+        <StartScreen onStart={() => setStarted(true)} onViewCv={() => setCvVisible(true)} isTouch={isTouch} />
+      )}
     </div>
   );
 }

--- a/src/ui/CvContent.test.tsx
+++ b/src/ui/CvContent.test.tsx
@@ -8,8 +8,8 @@
 // because browsers still search and expose that text; there is no way to
 // drive a browser's native find-in-page from this test runner to assert it
 // directly, so this file instead asserts the technique used is that one.
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { education } from '../data/education';
 import { hobbies } from '../data/hobbies';
 import { gardenBeds, pottedPlants, rackTools } from '../data/skills';
@@ -70,5 +70,60 @@ describe('CvContent', () => {
     }
     for (const plant of pottedPlants) expect(container.textContent).toContain(plant.name);
     for (const tool of rackTools) expect(container.textContent).toContain(tool.name);
+  });
+
+  // #17: the same content, made visible in place rather than clipped.
+  describe('visible', () => {
+    it('uses the cv-visible class instead of sr-only, with a close button', () => {
+      const { container } = render(<CvContent visible onClose={vi.fn()} />);
+      const root = container.firstElementChild!;
+      expect(root.className).toBe('cv-visible');
+      expect(screen.getByRole('button', { name: 'Close CV' })).toBeTruthy();
+    });
+
+    it('calls onClose when the close button is clicked', () => {
+      const onClose = vi.fn();
+      render(<CvContent visible onClose={onClose} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Close CV' }));
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('calls onClose on Escape', () => {
+      const onClose = vi.fn();
+      render(<CvContent visible onClose={onClose} />);
+      fireEvent.keyDown(window, { code: 'Escape' });
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('still renders every heading and entry when visible', () => {
+      render(<CvContent visible onClose={vi.fn()} />);
+      expect(screen.getAllByRole('heading', { level: 2 }).map((h) => h.textContent)).toEqual([
+        'Work Experience',
+        'Education',
+        'Skills',
+        'Hobbies',
+      ]);
+    });
+
+    it('moves focus into the panel on open, away from whatever was focused before', () => {
+      const outsideButton = document.createElement('button');
+      outsideButton.textContent = 'outside, focused before the panel opens';
+      document.body.appendChild(outsideButton);
+      outsideButton.focus();
+      expect(document.activeElement).toBe(outsideButton);
+
+      const { container } = render(<CvContent visible onClose={vi.fn()} />);
+
+      expect(document.activeElement).toBe(container.firstElementChild);
+      expect(document.activeElement).not.toBe(outsideButton);
+      outsideButton.remove();
+    });
+  });
+
+  it('ignores Escape when not visible (the always-mounted #8 instance is not a dialog)', () => {
+    const onClose = vi.fn();
+    render(<CvContent onClose={onClose} />);
+    fireEvent.keyDown(window, { code: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/CvContent.tsx
+++ b/src/ui/CvContent.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { education } from '../data/education';
 import { hobbies } from '../data/hobbies';
 import { profileData, summary } from '../data/profile';
@@ -5,11 +6,25 @@ import { gardenBeds, pottedPlants, rackTools } from '../data/skills';
 import { workExperience } from '../data/work-experience';
 import { TimelineItem } from '../data/types';
 
-// Always-mounted, visually-hidden text rendering of the CV. The game canvas
-// is aria-hidden and its dialogs only exist once a visitor has walked to and
-// interacted with something, so without this the CV has no representation
-// outside the canvas at all - unreachable by a screen reader, invisible to
-// find-in-page, and absent from the DOM for anything that doesn't play.
+interface CvContentProps {
+  // false (default): the always-mounted, screen-reader/find-in-page-only
+  // rendering from #8 - unchanged, no close button, identical output.
+  // true: the same content, same single heading structure, made visible
+  // in place instead of clipped - see #17. There is deliberately only
+  // ever one instance of this content in the DOM; toggling `visible`
+  // restyles it rather than mounting a second copy, so the page never
+  // ends up with the CV described twice at two different heading depths.
+  visible?: boolean;
+  onClose?: () => void;
+}
+
+// Always-mounted text rendering of the CV, visually hidden by default. The
+// game canvas is aria-hidden and its dialogs only exist once a visitor has
+// walked to and interacted with something, so without this the CV has no
+// representation outside the canvas at all - unreachable by a screen
+// reader, invisible to find-in-page, and absent from the DOM for anything
+// that doesn't play (#8). Passing `visible` additionally makes it seeable
+// on screen without playing at all (#17).
 //
 // This deliberately reads straight from src/data/*.ts rather than through
 // game/content/dialogs.ts's mapper functions (careerDialog, educationDialog,
@@ -19,9 +34,37 @@ import { TimelineItem } from '../data/types';
 // tuned for a compact dialog panel rather than a linear document. Reading
 // the data directly is simpler than routing through a shape built for a
 // different reader.
-export function CvContent() {
+export function CvContent({ visible = false, onClose }: CvContentProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // Escape-to-close, matching DialogPanel's existing pattern. Deliberately
+  // not E/Enter/Space too: those are the game's interact keys, and #17's
+  // AC2 is specifically that no game control is needed to see this content
+  // - binding them here would blur that line rather than clarify it.
+  useEffect(() => {
+    if (!visible) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code === 'Escape') onClose?.();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [visible, onClose]);
+
+  // Also matching DialogPanel: move focus into the panel on open. Without
+  // this, StartScreen's autoFocus'd Explore button - now covered but still
+  // in the DOM underneath - keeps keyboard focus, and a stray Enter/Space
+  // would start the game invisibly behind what looks like the CV panel.
+  useEffect(() => {
+    if (visible) rootRef.current?.focus();
+  }, [visible]);
+
   return (
-    <div className="sr-only">
+    <div ref={rootRef} className={visible ? 'cv-visible' : 'sr-only'} tabIndex={visible ? -1 : undefined}>
+      {visible && (
+        <button className="dialog-close cv-visible-close" onClick={onClose} aria-label="Close CV">
+          ✕
+        </button>
+      )}
       <h1>
         {profileData.name} — {profileData.title}
       </h1>

--- a/src/ui/StartScreen.test.tsx
+++ b/src/ui/StartScreen.test.tsx
@@ -1,0 +1,30 @@
+// First test for StartScreen - added alongside its one new behaviour (#17):
+// a "Read the CV" button distinct from Explore (starts the game) and the
+// PDF download, calling a plain callback rather than any game control.
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { StartScreen } from './StartScreen';
+
+describe('StartScreen', () => {
+  it('calls onViewCv, not onStart, when "Read the CV" is clicked', () => {
+    const onStart = vi.fn();
+    const onViewCv = vi.fn();
+    render(<StartScreen onStart={onStart} onViewCv={onViewCv} isTouch={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /read the cv/i }));
+
+    expect(onViewCv).toHaveBeenCalledOnce();
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('still calls onStart, not onViewCv, when Explore is clicked', () => {
+    const onStart = vi.fn();
+    const onViewCv = vi.fn();
+    render(<StartScreen onStart={onStart} onViewCv={onViewCv} isTouch={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /explore/i }));
+
+    expect(onStart).toHaveBeenCalledOnce();
+    expect(onViewCv).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/StartScreen.tsx
+++ b/src/ui/StartScreen.tsx
@@ -3,10 +3,11 @@ import { useDownloadPdf } from './useDownloadPdf';
 
 interface StartScreenProps {
   onStart: () => void;
+  onViewCv: () => void;
   isTouch: boolean;
 }
 
-export function StartScreen({ onStart, isTouch }: StartScreenProps) {
+export function StartScreen({ onStart, onViewCv, isTouch }: StartScreenProps) {
   const { busy, download } = useDownloadPdf();
 
   return (
@@ -39,13 +40,16 @@ export function StartScreen({ onStart, isTouch }: StartScreenProps) {
           <button className="pixel-button" onClick={onStart} autoFocus>
             ▶ Explore
           </button>
+          <button className="pixel-button secondary" onClick={onViewCv}>
+            📖 Read the CV
+          </button>
           <button className="pixel-button secondary" onClick={download} disabled={busy}>
             {busy ? 'Baking…' : '📄 Boring PDF version'}
           </button>
         </div>
         <p className="sr-only">
-          This page is an interactive game. If you prefer a standard document, use the download
-          button to get the CV as a PDF.
+          This page is an interactive game. If you'd rather not play, use "Read the CV" to see it
+          on this page, or download it as a PDF.
         </p>
       </div>
     </div>

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -302,6 +302,71 @@
   white-space: nowrap;
 }
 
+/* ---------------------------------- visible CV panel */
+/* CvContent with visible={true} (#17) - the same element .sr-only clips by
+   default, made a full-screen readable page instead. Constrained widths go
+   on each child rather than the container, which stays full-bleed so its
+   background/scrolling covers the whole viewport. */
+.cv-visible {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  overflow-y: auto;
+  background: var(--panel-bg);
+  color: var(--text);
+  text-align: left;
+  padding: 48px max(20px, env(safe-area-inset-right)) 48px max(20px, env(safe-area-inset-left));
+}
+
+.cv-visible h1,
+.cv-visible h2,
+.cv-visible h3,
+.cv-visible p,
+.cv-visible section {
+  max-width: 640px;
+  margin-inline: auto;
+}
+
+.cv-visible h1 {
+  font-size: 16px;
+  color: var(--accent);
+  line-height: 1.6;
+  margin-block: 0 12px;
+  padding-right: 40px; /* room for the fixed close button */
+}
+
+.cv-visible h2 {
+  font-size: 12px;
+  color: var(--accent);
+  margin-block: 26px 10px;
+  padding-top: 14px;
+  border-top: 2px dashed #c9b797;
+}
+
+.cv-visible h2:first-of-type {
+  margin-top: 20px;
+  border-top: none;
+  padding-top: 0;
+}
+
+.cv-visible h3 {
+  font-size: 10px;
+  margin-block: 14px 4px;
+}
+
+.cv-visible p {
+  font-size: 9px;
+  line-height: 1.9;
+  margin-block: 0 8px;
+}
+
+.cv-visible-close {
+  position: fixed;
+  top: max(16px, env(safe-area-inset-top));
+  right: max(16px, env(safe-area-inset-right));
+  z-index: 41;
+}
+
 /* ---------------------------------- touch controls */
 .touch-controls {
   position: absolute;


### PR DESCRIPTION
Closes #17

## What and why

#8 made the CV reachable by a screen reader and find-in-page, but its own PR named the
visible half as deliberately out of scope — `CvContent` stayed `.sr-only`. A sighted
visitor who does not want to play still had exactly two options: play, or download the
PDF. `rg -l 'workExperience|gardenBeds|education' src/ui src/App.tsx` confirmed nothing
else renders the CV data on screen. This adds a "Read the CV" button on the start screen
that reveals the same content in place, and fixes a real focus bug found while verifying
it in a browser.

## Acceptance criteria

- [x] A visitor who has not clicked Explore and does not download the PDF can see the
      content of every entry in `work-experience.ts`, `education.ts` and `skills.ts` on
      screen — `CvContent`'s `visible` prop; verified in a real browser (screenshot below)
      and by `CvContent.test.tsx`
- [x] No game control is required to reveal it — "Read the CV" is a plain `<button
      onClick>`, not a movement/interact key; `StartScreen.test.tsx` asserts it calls
      `onViewCv`, not `onStart`

## Existing code reused

- Extended `CvContent` (from #8) with a `visible` prop rather than writing a second
  component with the same data-mapping. There is deliberately only ever one instance of
  this content in the DOM — toggling `visible` restyles the existing element instead of
  mounting a duplicate, so the page never describes the CV twice at two different heading
  depths (a real alternative I considered and rejected — see Design notes).
- The close button reuses `DialogPanel`'s `.dialog-close` class outright (same look, same
  hover state), with one small positioning override (`.cv-visible-close`) since it isn't
  inside a flex header here.
- The focus-on-open fix mirrors `DialogPanel.tsx:17`'s `panelRef.current?.focus()` pattern
  exactly, including the `tabIndex={-1}` needed to make a `<div>` focusable at all.
- Considered building this out of `DialogPanel`/`DialogContent` directly (feed it one big
  `DialogContent` with many sections). Rejected: `DialogPanel` renders every
  `section.heading` as a flat `<h3>` with no group/item distinction, so 22 entries across
  4 categories would render as one undifferentiated list with no way to tell "Work
  Experience" from an individual job — the wrong shape for a categorized outline, not
  reusable without degrading the result.

## Design notes

No architecture change — one component gains a prop, two callers wire it up.

**Restyle one element, don't mount a second copy.** The alternative — a separate
`CvPanel`/`CvOverlay` component reusing only the *data* — was rejected specifically because
it would mount CvContent's h1/h2/h3 structure twice simultaneously whenever the panel was
open (the always-present `.sr-only` copy from #8, plus a new visible one), duplicating the
whole CV in the accessibility tree at once. Toggling one element's own class avoids that
by construction.

**A real bug, found by hand, not by the test suite.** After wiring the button up, driving
it in an actual browser (not just jsdom) surfaced that `StartScreen`'s `autoFocus`'d
Explore button kept keyboard focus underneath the now-visually-covering panel — nothing
had moved focus into it. A stray Enter/Space would have started the game invisibly behind
what looked like the CV. Fixed by mirroring `DialogPanel`'s existing focus-on-open pattern,
then added a test that reproduces it: temporarily reverting the fix while writing the test
confirmed it fails without the fix (see Verification). This is exactly the kind of thing
`CvContent.test.tsx`'s jsdom environment could have hidden — the bug was invisible in the
DOM structure itself, only in *what held focus*, which only manifested with the real
`autoFocus` browser behavior interacting across two components.

**Escape and the close button both work; the debugging process getting there is worth a
note for the reviewer.** Two things during browser verification looked broken and were
not: (1) reading `document.querySelectorAll('.cv-visible').length` synchronously right
after a synthetic `.click()` reads pre-render state — React's state update hadn't flushed
yet; (2) the same applies to `dispatchEvent` for Escape. Both resolved correctly once a
real delay was inserted between triggering and checking. Flagging this so nobody re-derives
the same false alarm from a similar quick check.

## Verification

- `npm run lint` / `npm run typecheck` / `npm run test` (37 passed) / `npm run build` — all
  clean on the final commit
- Broke the new "moves focus into the panel" test's underlying fix deliberately (commented
  out the `rootRef.current?.focus()` call), confirmed the test fails, restored it, confirmed
  it passes — proving the test actually catches the regression it targets
- Ran the flow in a real browser, with explicit delays between action and check (not
  synchronous reads) to avoid the false-alarm pattern above:
  - "Read the CV" click → `.cv-visible` present, focus on the panel (not the hidden Explore
    button underneath), game not started
  - Screenshot: readable page, `h1`/`h2`/`h3` structure, close button top-right
  - Escape closes it; the close button click closes it
  - Explore still starts the game and does not open the CV panel

## Out of scope

- No visual regression risk to `StartScreen`'s two existing buttons — `StartScreen.test.tsx`
  now covers both, but the button styling/behaviour itself is unchanged.
- The overlay's own scroll-restore-to-top on reopen isn't implemented — reopening after
  scrolling down resumes wherever the browser leaves a freshly-styled element (top, since
  it's the same DOM node whose scroll position resets when un-hidden in testing, but not
  guaranteed across browsers). Minor polish, not required by either acceptance criterion.

## Review focus

The focus-management fix (`CvContent.tsx`'s new `useEffect` + `tabIndex`) is the part
most worth a careful look — it's the one genuine bug this PR found and fixed, not just a
new feature.

*Implemented automatically from #17. Not reviewed, not merged.*
