### PR TITLE
feat(ui): trap keyboard focus inside dialogs and the CV panel

### DIFF
--- a/src/ui/CvContent.test.tsx
+++ b/src/ui/CvContent.test.tsx
@@ -118,6 +118,41 @@ describe('CvContent', () => {
       expect(document.activeElement).not.toBe(outsideButton);
       outsideButton.remove();
     });
+
+    // #19: the close button is the panel's only focusable element, so it is
+    // both first and last - Tab and Shift+Tab should each keep focus on it
+    // rather than escaping to a control hidden behind the panel (e.g.
+    // StartScreen's own buttons, still present in the DOM underneath).
+    // useFocusTrap.test.ts covers the trap's general wrapping behaviour;
+    // this just proves it's wired up here, in CvContent's own real shape.
+    it('traps Tab on its one focusable element (the close button)', () => {
+      render(<CvContent visible onClose={vi.fn()} />);
+      const closeBtn = screen.getByRole('button', { name: 'Close CV' });
+
+      // Initial focus lands on the panel itself (asserted above); once the
+      // close button has focus - however it got there - Tab/Shift+Tab must
+      // both keep it there rather than escaping to a hidden control.
+      closeBtn.focus();
+      fireEvent.keyDown(window, { code: 'Tab' });
+      expect(document.activeElement).toBe(closeBtn);
+
+      fireEvent.keyDown(window, { code: 'Tab', shiftKey: true });
+      expect(document.activeElement).toBe(closeBtn);
+    });
+
+    it('restores focus to "Read the CV" (or whatever opened it) when closed', () => {
+      const opener = document.createElement('button');
+      opener.textContent = 'Read the CV';
+      document.body.appendChild(opener);
+      opener.focus();
+
+      const { rerender } = render(<CvContent visible onClose={vi.fn()} />);
+      expect(document.activeElement).not.toBe(opener);
+
+      rerender(<CvContent visible={false} onClose={vi.fn()} />);
+      expect(document.activeElement).toBe(opener);
+      opener.remove();
+    });
   });
 
   it('ignores Escape when not visible (the always-mounted #8 instance is not a dialog)', () => {

--- a/src/ui/CvContent.tsx
+++ b/src/ui/CvContent.tsx
@@ -5,6 +5,7 @@ import { profileData, summary } from '../data/profile';
 import { gardenBeds, pottedPlants, rackTools } from '../data/skills';
 import { workExperience } from '../data/work-experience';
 import { TimelineItem } from '../data/types';
+import { useFocusTrap } from './useFocusTrap';
 
 interface CvContentProps {
   // false (default): the always-mounted, screen-reader/find-in-page-only
@@ -36,6 +37,7 @@ interface CvContentProps {
 // different reader.
 export function CvContent({ visible = false, onClose }: CvContentProps) {
   const rootRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(rootRef, visible);
 
   // Escape-to-close, matching DialogPanel's existing pattern. Deliberately
   // not E/Enter/Space too: those are the game's interact keys, and #17's
@@ -49,14 +51,6 @@ export function CvContent({ visible = false, onClose }: CvContentProps) {
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [visible, onClose]);
-
-  // Also matching DialogPanel: move focus into the panel on open. Without
-  // this, StartScreen's autoFocus'd Explore button - now covered but still
-  // in the DOM underneath - keeps keyboard focus, and a stray Enter/Space
-  // would start the game invisibly behind what looks like the CV panel.
-  useEffect(() => {
-    if (visible) rootRef.current?.focus();
-  }, [visible]);
 
   return (
     <div ref={rootRef} className={visible ? 'cv-visible' : 'sr-only'} tabIndex={visible ? -1 : undefined}>

--- a/src/ui/DialogPanel.test.tsx
+++ b/src/ui/DialogPanel.test.tsx
@@ -2,7 +2,7 @@
 // half of "reachable in the rendered output" that dialogs.test.ts cannot
 // cover on its own, since that file only exercises the data -> DialogContent
 // transform. Together the two files cover the full path for issue #13.
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { workExperience } from '../data/work-experience';
 import { gardenBeds } from '../data/skills';
@@ -29,5 +29,26 @@ describe('DialogPanel', () => {
     for (const skill of gardenBeds[0].skills) {
       expect(screen.getByText(skill)).toBeTruthy();
     }
+  });
+
+  // #19: DialogPanel and CvContent share useFocusTrap (see its own test
+  // file for the trap's own behaviour in detail); this just proves the
+  // trap is actually wired up here, using a dialog with an action button
+  // so there are two real focusable elements to wrap between.
+  it('traps Tab between its two focusable elements: close and the action button', () => {
+    const content = careerDialog(workExperience[0]);
+    content.action = { label: 'Teleport back home', type: 'teleport-home' };
+    render(<DialogPanel content={content} onClose={vi.fn()} onAction={vi.fn()} isTouch={false} />);
+
+    const closeBtn = screen.getByRole('button', { name: 'Close dialog' });
+    const actionBtn = screen.getByRole('button', { name: 'Teleport back home' });
+    expect(document.activeElement).toBe(screen.getByRole('dialog'));
+
+    actionBtn.focus();
+    fireEvent.keyDown(window, { code: 'Tab' });
+    expect(document.activeElement).toBe(closeBtn);
+
+    fireEvent.keyDown(window, { code: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(actionBtn);
   });
 });

--- a/src/ui/DialogPanel.tsx
+++ b/src/ui/DialogPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { DialogAction, DialogContent } from '../game/events';
+import { useFocusTrap } from './useFocusTrap';
 
 interface DialogPanelProps {
   content: DialogContent;
@@ -12,9 +13,9 @@ const CLOSE_KEYS = new Set(['Escape', 'KeyE', 'Enter', 'Space']);
 
 export function DialogPanel({ content, onClose, onAction, isTouch }: DialogPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(panelRef, true);
 
   useEffect(() => {
-    panelRef.current?.focus();
     const onKeyDown = (e: KeyboardEvent) => {
       if (CLOSE_KEYS.has(e.code)) {
         e.preventDefault();

--- a/src/ui/useFocusTrap.test.ts
+++ b/src/ui/useFocusTrap.test.ts
@@ -1,0 +1,120 @@
+// useFocusTrap is exercised through a minimal harness rather than through
+// DialogPanel/CvContent directly, so these assertions are about the trap
+// itself (initial focus, Tab/Shift+Tab wrapping, restore-on-close) and stay
+// meaningful even if either caller's own markup changes later. Each real
+// caller gets its own lighter integration check in its own test file.
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useFocusTrap } from './useFocusTrap';
+
+// Builds container > [firstBtn, middleBtn, lastBtn], with `outside` as a
+// sibling standing in for a control hidden behind the overlay (e.g.
+// StartScreen's buttons behind the CV panel, or anything behind a dialog).
+function buildHarness() {
+  const outside = document.createElement('button');
+  outside.textContent = 'outside';
+  document.body.appendChild(outside);
+
+  const container = document.createElement('div');
+  container.tabIndex = -1;
+  const firstBtn = document.createElement('button');
+  firstBtn.textContent = 'first';
+  const middleBtn = document.createElement('button');
+  middleBtn.textContent = 'middle';
+  const lastBtn = document.createElement('button');
+  lastBtn.textContent = 'last';
+  container.append(firstBtn, middleBtn, lastBtn);
+  document.body.appendChild(container);
+
+  return { outside, container, firstBtn, middleBtn, lastBtn };
+}
+
+describe('useFocusTrap', () => {
+  it('focuses the container and remembers the previously-focused trigger', () => {
+    const { outside, container } = buildHarness();
+    outside.focus();
+
+    const { rerender } = renderHook(({ active }) => useFocusTrap({ current: container }, active), {
+      initialProps: { active: false },
+    });
+    expect(document.activeElement).toBe(outside);
+
+    rerender({ active: true });
+    expect(document.activeElement).toBe(container);
+
+    outside.remove();
+    container.remove();
+  });
+
+  it('wraps Tab from the last focusable element back to the first', () => {
+    const { container, firstBtn, lastBtn } = buildHarness();
+    renderHook(() => useFocusTrap({ current: container }, true));
+
+    lastBtn.focus();
+    const event = new KeyboardEvent('keydown', { code: 'Tab', bubbles: true, cancelable: true });
+    act(() => window.dispatchEvent(event));
+
+    expect(document.activeElement).toBe(firstBtn);
+    expect(event.defaultPrevented).toBe(true);
+    container.remove();
+  });
+
+  it('wraps Shift+Tab from the first focusable element back to the last', () => {
+    const { container, firstBtn, lastBtn } = buildHarness();
+    renderHook(() => useFocusTrap({ current: container }, true));
+
+    firstBtn.focus();
+    const event = new KeyboardEvent('keydown', { code: 'Tab', shiftKey: true, bubbles: true, cancelable: true });
+    act(() => window.dispatchEvent(event));
+
+    expect(document.activeElement).toBe(lastBtn);
+    expect(event.defaultPrevented).toBe(true);
+    container.remove();
+  });
+
+  it('does not interfere with Tab between elements inside the container', () => {
+    const { container, firstBtn, middleBtn } = buildHarness();
+    renderHook(() => useFocusTrap({ current: container }, true));
+
+    firstBtn.focus();
+    const event = new KeyboardEvent('keydown', { code: 'Tab', bubbles: true, cancelable: true });
+    act(() => window.dispatchEvent(event));
+
+    // Real browser tab order would move focus to middleBtn on its own;
+    // jsdom does not implement that, so this only asserts the trap itself
+    // stayed out of the way (didn't force focus back to first/last).
+    expect(event.defaultPrevented).toBe(false);
+    container.remove();
+    void middleBtn;
+  });
+
+  it('restores focus to the trigger when deactivated', () => {
+    const { outside, container } = buildHarness();
+    outside.focus();
+
+    const { rerender } = renderHook(({ active }) => useFocusTrap({ current: container }, active), {
+      initialProps: { active: true },
+    });
+    expect(document.activeElement).toBe(container);
+
+    rerender({ active: false });
+    expect(document.activeElement).toBe(outside);
+
+    outside.remove();
+    container.remove();
+  });
+
+  it('restores focus to the trigger when unmounted', () => {
+    const { outside, container } = buildHarness();
+    outside.focus();
+
+    const { unmount } = renderHook(() => useFocusTrap({ current: container }, true));
+    expect(document.activeElement).toBe(container);
+
+    unmount();
+    expect(document.activeElement).toBe(outside);
+
+    outside.remove();
+    container.remove();
+  });
+});

--- a/src/ui/useFocusTrap.ts
+++ b/src/ui/useFocusTrap.ts
@@ -1,0 +1,49 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+// Standard modal "focus trap": https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
+// - Tab/Shift+Tab cycle only among elements inside the container while
+// `active`, and deactivating restores focus to whatever held it before.
+// Shared by DialogPanel and CvContent, the app's only two full-screen
+// overlays - both previously only set initial focus with nothing keeping
+// it inside, so a keyboard user could Tab straight through to a control
+// hidden behind the overlay and activate it without seeing it (#19).
+export function useFocusTrap(containerRef: RefObject<HTMLElement | null>, active: boolean): void {
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    triggerRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    container.focus();
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code !== 'Tab') return;
+      const focusable = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const atStart = document.activeElement === first || document.activeElement === container;
+      if (e.shiftKey && atStart) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      triggerRef.current?.focus();
+    };
+  }, [active, containerRef]);
+}


### PR DESCRIPTION
Closes #19

## What and why

Neither of the app's two full-screen overlays — `DialogPanel` and `CvContent`'s visible
mode (#17) — trapped keyboard focus; each only set it once on open. A keyboard user could
Tab straight through to a control still fully present underneath (e.g. `StartScreen`'s own
buttons, still in the DOM and the tab order behind the CV panel) and activate it without
seeing what they just did. Adds a shared `useFocusTrap` hook implementing the standard
WAI-ARIA modal pattern, wired into both.

## Acceptance criteria

- [x] With the CV panel open, Tab cycles only among elements inside it, never reaching a
      control underneath — `useFocusTrap.test.ts`, plus `CvContent.test.tsx`'s own
      integration test against the real component; verified live in a real browser (see
      Verification)
- [x] With a dialog (`DialogPanel`) open, same — `DialogPanel.test.tsx`'s new test builds a
      dialog with a real action button so there are two distinct focusable elements to wrap
      between, not just the always-present close button
- [x] Closing either overlay returns focus somewhere sensible, not lost to `<body>` —
      `useFocusTrap`'s cleanup restores focus to whatever was focused before activation;
      covered by both the hook's own tests and both integration tests

## Existing code reused

- One hook, not two. The trap logic has nothing to do with what's inside the container —
  unlike #17's CvContent/DialogContent decision (where the two things being compared were
  structurally different documents), this is a textbook shared-abstraction case: identical
  behaviour needed at both call sites, a named pattern with a standard definition.
- `DialogPanel` drops its own `panelRef.current?.focus()` line in favour of
  `useFocusTrap(panelRef, true)` — it's only ever rendered while a dialog is open, so the
  trap's lifetime matches the component's mount/unmount exactly, a direct swap.
- `CvContent` drops its equivalent effect (added in #17) for
  `useFocusTrap(rootRef, visible)` — since it stays permanently mounted (#8), this exercises
  the hook's full activate/deactivate toggle across one instance's lifetime, not just
  mount/unmount.
- Each component's own `Escape`-to-close `useEffect` is untouched — that's a separate
  concern (closing the overlay) from focus containment while it's open, and both already
  worked correctly.

## Design notes

No architecture change — one new hook, two existing components each swap one effect for it.

**Implemented directly rather than adding a dependency.** Checked the manifest first: no
`focus-trap`/`react-focus-lock`/similar exists. The pattern itself is short (~40 lines,
[WAI-ARIA's own documented technique](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/))
and has exactly two call sites — pulling in a whole library's API surface for that is
disproportionate; a small, correct, in-repo implementation is the better trade here.

**A real, hard-won finding about the browser-automation tooling used to verify this, worth
recording so nobody re-derives it.** The `computer` tool's synthesized "key" presses are
genuinely trusted DOM events (`isTrusted: true`) but populate `KeyboardEvent.key` correctly
while leaving `.code` empty (`""`). `useFocusTrap`, matching this codebase's own existing
convention (`DialogPanel`'s pre-existing `CLOSE_KEYS` set already checks `.code`, not
`.key`), checks `e.code === 'Tab'` — so pressing Tab via that specific tool never reached
the handler at all, and the trap appeared to fail. A real physical keyboard, in every
evergreen browser, always populates `.code` for hardware key presses — this is standard,
long-established web-platform behaviour, unrelated to what any one automation tool's key
synthesis happens to omit. Verified the actual logic is correct by dispatching a
`KeyboardEvent` with `code: 'Tab'` set explicitly (same technique `fireEvent.keyDown` and
`dispatchEvent` use throughout this repo's existing tests) against the real, running app in
a real Chromium browser pane — not just jsdom — and confirmed the wrap and focus-restore
both behave exactly as the unit tests say. Left `.code`-based checks as-is rather than
switching to `.key`, to stay consistent with the codebase's existing convention rather than
introduce a second one to work around a testing tool's quirk.

## Verification

- `npm run lint` / `npm run typecheck` / `npm run test` (46 passed) / `npm run build` — all
  clean on the final commit
- Broke the trap's boundary-detection deliberately (`atStart` hardcoded to `false`),
  confirmed two tests fail — one in `useFocusTrap.test.ts`, one in `DialogPanel.test.tsx`'s
  real-component integration test — restored it, confirmed all 46 pass again
- Ran the CV panel in a real browser (not jsdom): opened it, manually focused the close
  button, dispatched `Tab` (code set correctly) — focus stayed on the close button;
  dispatched `Shift+Tab` — stayed; dispatched `Escape` — closed and focus returned to the
  "Read the CV" button that opened it
- Also confirmed a *plain* click flow works with the browser's own genuinely native
  first hop (container → close button via a real, trusted Tab press) before hitting the
  tool's `.code` limitation on the second press — see Design notes for why that limitation
  doesn't reflect real user behaviour

## Out of scope

- `TouchControls`' d-pad buttons being unfocusable `<div>`s (a separate, already-tracked
  gap under #12) — untouched here, not a focus-trap concern.
- `prefers-reduced-motion` (also #12) — unrelated to keyboard focus.

## Review focus

The "Design notes" section on the browser-automation tooling quirk is worth reading even if
you skim the rest — it explains why the PR's own verification had to route around a real
oddity in the test environment, and it'll save whoever touches this next from rediscovering
it the hard way.

*Implemented automatically from #19. Not reviewed, not merged.*
