### PR TITLE
feat(ui): show the CV as a scrolling page on landing, not a game start screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,11 @@ function App() {
   const [dialog, setDialog] = useState<DialogContent | null>(null);
   const [prompt, setPrompt] = useState<string | null>(null);
   const [scene, setScene] = useState<SceneName>('overworld');
-  const [cvVisible, setCvVisible] = useState(false);
+  // #26: the CV is the landing view, visible on load with no click-through -
+  // closing it (or Escape) reveals the game underneath instead of the other
+  // way around, matching backlog-conventions.md's "readable without playing"
+  // direction while keeping the free-roam game itself untouched and reachable.
+  const [cvVisible, setCvVisible] = useState(true);
 
   const isTouch = useMemo(
     () =>

--- a/src/ui/CvContent.test.tsx
+++ b/src/ui/CvContent.test.tsx
@@ -105,6 +105,15 @@ describe('CvContent', () => {
       ]);
     });
 
+    // #26: the CV is now the landing view, so the PDF (the recruiter's
+    // documented escape hatch) must be reachable from here directly rather
+    // than only from StartScreen.
+    it('offers a PDF download button, not disabled by default', () => {
+      render(<CvContent visible onClose={vi.fn()} />);
+      const pdfButton = screen.getByRole('button', { name: /download as pdf/i }) as HTMLButtonElement;
+      expect(pdfButton.disabled).toBe(false);
+    });
+
     it('moves focus into the panel on open, away from whatever was focused before', () => {
       const outsideButton = document.createElement('button');
       outsideButton.textContent = 'outside, focused before the panel opens';
@@ -119,25 +128,26 @@ describe('CvContent', () => {
       outsideButton.remove();
     });
 
-    // #19: the close button is the panel's only focusable element, so it is
-    // both first and last - Tab and Shift+Tab should each keep focus on it
+    // #19 (updated by #26, which added the PDF button as a second focusable
+    // element): Tab/Shift+Tab must wrap between the panel's two focusable
+    // controls - the close button (first) and the PDF button (last) -
     // rather than escaping to a control hidden behind the panel (e.g.
     // StartScreen's own buttons, still present in the DOM underneath).
     // useFocusTrap.test.ts covers the trap's general wrapping behaviour;
     // this just proves it's wired up here, in CvContent's own real shape.
-    it('traps Tab on its one focusable element (the close button)', () => {
+    it('traps Tab between its close and PDF buttons', () => {
       render(<CvContent visible onClose={vi.fn()} />);
       const closeBtn = screen.getByRole('button', { name: 'Close CV' });
+      const pdfBtn = screen.getByRole('button', { name: /download as pdf/i });
 
-      // Initial focus lands on the panel itself (asserted above); once the
-      // close button has focus - however it got there - Tab/Shift+Tab must
-      // both keep it there rather than escaping to a hidden control.
-      closeBtn.focus();
+      // Tab forward from the last focusable element wraps to the first.
+      pdfBtn.focus();
       fireEvent.keyDown(window, { code: 'Tab' });
       expect(document.activeElement).toBe(closeBtn);
 
+      // Shift+Tab backward from the first focusable element wraps to the last.
       fireEvent.keyDown(window, { code: 'Tab', shiftKey: true });
-      expect(document.activeElement).toBe(closeBtn);
+      expect(document.activeElement).toBe(pdfBtn);
     });
 
     it('restores focus to "Read the CV" (or whatever opened it) when closed', () => {

--- a/src/ui/CvContent.tsx
+++ b/src/ui/CvContent.tsx
@@ -5,6 +5,7 @@ import { profileData, summary } from '../data/profile';
 import { gardenBeds, pottedPlants, rackTools } from '../data/skills';
 import { workExperience } from '../data/work-experience';
 import { TimelineItem } from '../data/types';
+import { useDownloadPdf } from './useDownloadPdf';
 import { useFocusTrap } from './useFocusTrap';
 
 interface CvContentProps {
@@ -25,7 +26,9 @@ interface CvContentProps {
 // representation outside the canvas at all - unreachable by a screen
 // reader, invisible to find-in-page, and absent from the DOM for anything
 // that doesn't play (#8). Passing `visible` additionally makes it seeable
-// on screen without playing at all (#17).
+// on screen without playing at all (#17) - and App.tsx now renders it
+// `visible` by default, making this the site's landing view rather than
+// something reached by clicking through a game (#26).
 //
 // This deliberately reads straight from src/data/*.ts rather than through
 // game/content/dialogs.ts's mapper functions (careerDialog, educationDialog,
@@ -38,6 +41,7 @@ interface CvContentProps {
 export function CvContent({ visible = false, onClose }: CvContentProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   useFocusTrap(rootRef, visible);
+  const { busy, download } = useDownloadPdf();
 
   // Escape-to-close, matching DialogPanel's existing pattern. Deliberately
   // not E/Enter/Space too: those are the game's interact keys, and #17's
@@ -64,6 +68,15 @@ export function CvContent({ visible = false, onClose }: CvContentProps) {
       </h1>
       <p>{profileData.bio}</p>
       <p>{summary}</p>
+      {visible && (
+        // #26: this is now the landing view, so the PDF (the recruiter's
+        // documented escape hatch, see backlog-conventions.md) must be
+        // reachable from here directly - reusing StartScreen's own
+        // useDownloadPdf hook rather than a second copy of the same logic.
+        <button className="pixel-button secondary cv-pdf-button" onClick={download} disabled={busy}>
+          {busy ? 'Baking…' : '📄 Download as PDF'}
+        </button>
+      )}
 
       <h2>Work Experience</h2>
       {workExperience.map((item) => (

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -322,9 +322,15 @@
 .cv-visible h2,
 .cv-visible h3,
 .cv-visible p,
-.cv-visible section {
+.cv-visible section,
+.cv-visible .cv-pdf-button {
   max-width: 640px;
   margin-inline: auto;
+}
+
+.cv-visible .cv-pdf-button {
+  display: block;
+  margin-block: 4px 8px;
 }
 
 .cv-visible h1 {


### PR DESCRIPTION
Closes #26

## What and why

Visiting the site used to require clicking past a "Play" gate (`StartScreen`) before the
CV became visible — the exact "gate content behind exploration" problem
`.claude/backlog-conventions.md` names as the reason the free-roam game is being replaced.
This flips the default: `App.tsx` now renders `CvContent` visible on load, so all four
sections (career, education, skills, hobbies) are readable immediately, in order, with no
click-through. The free-roam game isn't removed — closing the CV panel reveals it
underneath exactly as before, just no longer the default. This is the first, deliberately
small slice of #25's rewrite; the per-section pixel scenes and the rest of the shell
replacement are separate future work, not attempted here.

## Acceptance criteria

- [x] All CV sections readable on load, no click-through — `App.tsx`'s `cvVisible` now
      defaults `true`; verified live in a real browser (see Verification)
- [x] Sections appear in a fixed order while scrolling — unchanged from `CvContent.tsx`'s
      existing render order (Work Experience → Education → Skills → Hobbies), confirmed via
      `get_page_text` in the browser
- [x] PDF reachable from this page without interacting with any animation — `CvContent.tsx`
      gained its own download button (see below); clicked it live, no console errors, no
      stuck busy state

## Existing code reused

- No new component. `CvContent` (#8/#17) and its focus trap (`useFocusTrap`, #19) already
  existed and already worked exactly like this when opened via "Read the CV" — this PR
  only changes which state they start in.
- The new PDF button reuses `useDownloadPdf()` unchanged — the same hook `StartScreen`
  already calls. No second PDF-triggering code path.
- `StartScreen`, `GameCanvas`, `HUD`, `TouchControls`, the whole engine — untouched. Closing
  the CV panel reveals them exactly as `cvVisible={false}` already did before this PR.

## Design notes

No architecture change — a default-value flip plus one reused hook wired into an existing
component. No new abstraction: the PDF button is a second `<button>` in the same component
that already renders a close button the same way.

The one real design decision: keep the game underneath rather than deleting it. Feature
#25 explicitly lists removing the engine as *out of scope* for now ("a consequence of
stories under this feature landing, not something to schedule as its own task") — this
story is about what a visitor sees first, not about deleting code, so `App.tsx` keeps
`GameCanvas`/`StartScreen` mounted and paused underneath, reachable via the existing close
button, same as today.

`.cv-visible`'s CSS already centers `h1`/`h2`/`h3`/`p`/`section` at a 640px max-width;
extended that same selector to the new `.cv-pdf-button` rather than inventing separate
positioning rules, so the button lines up with the text column around it.

## Verification

- `npm run lint` / `npm run typecheck` / `npm run test` (48 passed) / `npm run build` — all
  clean
- Negative-case proof: temporarily broke the new PDF-button test's expected accessible
  name; confirmed it — and the updated focus-trap test, which looks up the same button —
  both failed with the real assertion error, then restored and confirmed all 48 pass again
- Real browser (dev server): loading the root URL shows the full CV immediately, all four
  sections present in order via `get_page_text`, only the close and PDF buttons are
  keyboard-reachable while the panel is up (`read_page` interactive listing), closing the
  panel reveals the paused game/StartScreen underneath, clicking "Download as PDF"
  completes with no console errors

## Out of scope

- Per-section pixel scenes, removing the free-roam engine/world/entity code, and the rest
  of #25's rewrite — this is its first slice, not the whole thing.
- The `downloadPdf` chunk's ~1.47MB size (pre-existing, flagged already under #23/#11) —
  unrelated to this change, which only adds a second call site for an existing hook.
- Any UX-copy changes to `StartScreen`'s own text (still describes itself as the primary
  way in) — leaving that for whichever future #25 story actually changes what's revealed
  when the CV panel is closed.

## Review focus

The focus-trap test update (`CvContent.test.tsx`) is the part most worth a close look —
it now asserts wrapping between two buttons instead of one, which is easy to get backwards.

*Implemented automatically from #26. Not reviewed, not merged.*
