### PR TITLE
fix(ui): correct the game screen's copy now that it's not the landing view

### DIFF
--- a/src/ui/StartScreen.test.tsx
+++ b/src/ui/StartScreen.test.tsx
@@ -27,4 +27,20 @@ describe('StartScreen', () => {
     expect(onStart).toHaveBeenCalledOnce();
     expect(onViewCv).not.toHaveBeenCalled();
   });
+
+  // #28: since #26 made the CV the default landing view, this screen is reached
+  // by leaving it rather than being the site's front door - its copy should say so.
+  describe('copy reflects that the CV, not this screen, is the landing view', () => {
+    it('describes itself as reached from the CV, not as the entry point', () => {
+      render(<StartScreen onStart={vi.fn()} onViewCv={vi.fn()} isTouch={false} />);
+      expect(screen.getByText(/stepped out of the cv/i)).toBeTruthy();
+      expect(screen.queryByText(/welcome to my little pixel-world cv/i)).toBeNull();
+    });
+
+    it('tells a screen reader user "Read the CV" goes back, not that it is the non-playing option', () => {
+      render(<StartScreen onStart={vi.fn()} onViewCv={vi.fn()} isTouch={false} />);
+      expect(screen.getByText(/go back to it/i)).toBeTruthy();
+      expect(screen.queryByText(/this page is an interactive game/i)).toBeNull();
+    });
+  });
 });

--- a/src/ui/StartScreen.tsx
+++ b/src/ui/StartScreen.tsx
@@ -19,9 +19,9 @@ export function StartScreen({ onStart, onViewCv, isTouch }: StartScreenProps) {
         <h2>Magnus Arnild</h2>
         <h3>Software Engineer · Interactive CV</h3>
         <p>
-          Welcome to my little pixel-world CV! Walk around and find out about me: the forest holds
-          my career, the garden grows my skills, the mountains represent my education — and my
-          hobbies are spread all over the world.
+          You've stepped out of the CV and into the pixel world it's built from. Walk around and
+          find out more: the forest holds my career, the garden grows my skills, the mountains
+          represent my education — and my hobbies are spread all over the world.
         </p>
         <div className="start-controls">
           {isTouch ? (
@@ -48,8 +48,8 @@ export function StartScreen({ onStart, onViewCv, isTouch }: StartScreenProps) {
           </button>
         </div>
         <p className="sr-only">
-          This page is an interactive game. If you'd rather not play, use "Read the CV" to see it
-          on this page, or download it as a PDF.
+          This is an optional interactive game mode, reached by leaving the main CV page. Use
+          "Read the CV" to go back to it, or download it as a PDF from here.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Closes #28

## What and why

`StartScreen.tsx`'s copy was written back when it was the first thing a visitor saw
(#8/#17): "Welcome to my little pixel-world CV!" and an `sr-only` note framing "Read the
CV" as the alternative to playing. Since #26 made the CV the default landing view, this
screen is now reached by *closing* that CV — the relationship inverted, and the old copy
no longer describes what's actually happening. This PR only corrects the text to match.

## Acceptance criteria

- [x] Copy accurately reflects this is an optional game mode reached from the CV, not the
      site's front door — new welcome text: "You've stepped out of the CV and into the
      pixel world it's built from..." (`StartScreen.tsx:22`)
- [x] The `sr-only` paragraph no longer frames "Read the CV" as the alternative to playing
      — it now says it goes *back* to the CV (`StartScreen.tsx:51`)

## Existing code reused

- Text-only change. No new component, no new prop, no new hook — `onViewCv`/`onStart`/
  `download` and their wiring in `App.tsx` are untouched.

## Design notes

No architecture change, no new pattern — a copy correction following directly from #26's
behavior change. Button labels ("Explore", "Read the CV", "Boring PDF version") were left
as-is: the issue's acceptance criteria are about the two paragraphs, and changing button
labels too would be scope creep beyond what #28 asked for.

## Verification

- `npm run lint` / `npm run typecheck` / `npm run test` (50 passed) / `npm run build` — all
  clean
- Negative-case proof: temporarily corrupted the new "stepped out of the cv" test's search
  string, confirmed it failed with the real assertion error, restored and confirmed all 50
  pass again
- Real browser (dev server): loaded the site, closed the CV panel, confirmed via
  `get_page_text` that the game screen now reads "You've stepped out of the CV and into the
  pixel world it's built from..." and the sr-only text says "...Use 'Read the CV' to go
  back to it..."

## Out of scope

- Button label wording ("Read the CV" now returns to a CV you've already seen, which reads
  slightly oddly but is still literally accurate) — left as noticed, not fixed, per the
  issue's own scope.
- Anything else under #25's wider rewrite (per-section pixel scenes, eventually removing
  the free-roam gate) — unrelated to this text-only fix.

## Review focus

Just the two rewritten paragraphs — this is a small, low-risk copy fix.

*Implemented automatically from #28. Not reviewed, not merged.*
